### PR TITLE
Update Test.hs

### DIFF
--- a/Crypto/Random/Test.hs
+++ b/Crypto/Random/Test.hs
@@ -50,6 +50,7 @@ randomTestAppend (RandomTestState buckets) = loop
                 let (b1,b2) = L.splitAt monteN bs
                 mapM_ (addVec 1 . fromIntegral) $ L.unpack b1
                 loop b2
+        addVec :: Word64 -> Int -> IO ()
         addVec a i = M.read buckets i >>= \d -> M.write buckets i $! d+a
 
 -- | Finalize random test state into some result


### PR DESCRIPTION
I was trying to build this with with ghc-head and got the following complaint. Things are fine if I add TypeFamilies, but it seemed better just to add a clarifying signature `addVec :: Word64 -> Int -> IO ()`

```
Crypto/Random/Test.hs:53:9:
Illegal equational constraint primitive-0.5.3.0:Control.Monad.Primitive.PrimState
                                m
                              ~ ghc-prim:GHC.Prim.RealWorld
(Use GADTs or TypeFamilies to permit this)
When checking that ‘addVec’ has the inferred type
  addVec :: forall (m :: * -> *).
            (primitive-0.5.3.0:Control.Monad.Primitive.PrimMonad m,
             primitive-0.5.3.0:Control.Monad.Primitive.PrimState m
             ~ ghc-prim:GHC.Prim.RealWorld) =>
            Word64 -> Int -> m ()
In an equation for ‘randomTestAppend’:
    randomTestAppend (RandomTestState buckets)
      = loop
      where
          loop bs
            | L.null bs = return ()
            | otherwise
            = do { let ...;
                   .... }
          addVec a i = M.read buckets i >>= \ d -> M.write buckets i $! d + a
```
