### PR TITLE
Added GADTs flag required by ghc-7.9

### DIFF
--- a/Crypto/Random/Test.hs
+++ b/Crypto/Random/Test.hs
@@ -7,6 +7,8 @@
 --
 -- Provide way to test usual simple statisticals test for randomness
 --
+{-# LANGUAGE GADTs #-}
+
 module Crypto.Random.Test
     ( RandomTestState
     , RandomTestResult(..)


### PR DESCRIPTION
Your library didn't not compile under ghc-7.9 without GADTs flag in Crypto.Random.Test. I added it.
