### PR TITLE
Require Cabal-Version 1.8

### DIFF
--- a/crypto-random.cabal
+++ b/crypto-random.cabal
@@ -10,7 +10,7 @@ Synopsis:            Simple cryptographic random related types
 Category:            Cryptography
 Build-Type:          Simple
 Homepage:            http://github.com/vincenthz/hs-crypto-random
-Cabal-Version:       >=1.6
+Cabal-Version:       >=1.8
 
 Library
   Build-depends:     base >= 4 && < 5


### PR DESCRIPTION
```
Warning: crypto-random.cabal:16:34: version operators used. To use version                                                                                                                                                                                                         
operators the package needs to specify at least 'cabal-version: >= 1.8'.      
```