### PR TITLE
Update for unix-2.8

### DIFF
--- a/Crypto/Random/Entropy/Unix.hs
+++ b/Crypto/Random/Entropy/Unix.hs
@@ -48,7 +48,7 @@ testOpen filepath = do
         Just h  -> closeDev h >> return (Just filepath)
 
 openDev :: String -> IO (Maybe H)
-openDev filepath = (Just `fmap` openFd filepath ReadOnly Nothing fileFlags)
+openDev filepath = (Just `fmap` openFd filepath ReadOnly fileFlags)
     `E.catch` \(_ :: IOException) -> return Nothing
   where fileFlags = defaultFileFlags { nonBlock = True }
 


### PR DESCRIPTION
The signature of `openFd` changed in unix-2.8 https://hackage.haskell.org/package/unix-2.8.1.0/docs/System-Posix-IO.html#v:openFd